### PR TITLE
jsを受け取る属性値で扱える書式を増やす

### DIFF
--- a/libs/chart/_base.js
+++ b/libs/chart/_base.js
@@ -1,7 +1,7 @@
 import d3 from 'd3'
 import dc from 'dc'
 import Store from '../store'
-import {generateDomId} from '../utils'
+import {generateDomId, generateExtractor} from '../utils'
 
 
 export default {
@@ -14,10 +14,8 @@ export default {
       default: 'default'
     },
     dimension: {
-      type: String
     },
     reduce: {
-      type: String
     },
     id: {
       type: String,
@@ -43,10 +41,10 @@ export default {
       return this.dimension;
     },
     getDimensionExtractor: function() {
-      return new Function('d', 'return ' + this.dimension)
+      return generateExtractor(this.dimension)
     },
     getReducerExtractor: function() {
-      return new Function('d', 'return ' + this.reduce)
+      return generateExtractor(this.reduce)
     },
     grouping: function() {
       const grouping = this.getDimensionExtractor;

--- a/libs/chart/_composite.js
+++ b/libs/chart/_composite.js
@@ -1,7 +1,7 @@
 import Vue from 'vue/dist/vue.js'
 import d3 from 'd3'
 import Base from './_base'
-
+import {generateExtractor} from '../utils'
 
 export function compose(Left, Right) {
 
@@ -29,7 +29,7 @@ export function compose(Left, Right) {
           },
           getReducerExtractor: () => {
             return (d) => {
-              const _reducer = new Function('d', 'return ' + this.reduce);
+              const _reducer = generateExtractor(this.reduce);
               return _reducer(d)[0];
             }
           }
@@ -48,7 +48,7 @@ export function compose(Left, Right) {
           },
           getReducerExtractor: () => {
             return (d) => {
-              const _reducer = new Function('d', 'return ' + this.reduce);
+              const _reducer = generateExtractor(this.reduce);
               return _reducer(d)[1];
             }
           }

--- a/libs/utils/index.js
+++ b/libs/utils/index.js
@@ -1,3 +1,4 @@
+
 export function generateUUID() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
@@ -5,6 +6,44 @@ export function generateUUID() {
   })
 }
 
+
 export function generateDomId() {
   return 'id-' + generateUUID();
+}
+
+
+// String(js): <data-table columns="{key: d.key}"></data-table>
+// Object: <data-table :columns="{key: "key"}"></data-table>
+// Array: <data-table :columns="["key"]"></data-table>
+// Function: <data-table :columns="customParser"></data-table>
+export function generateExtractor (rule) {
+  if (typeof rule === 'function' || rule instanceof Function) {
+    return rule
+  }
+
+  else if (typeof rule === "string" || rule instanceof String) {
+    return new Function('d', 'return ' + rule)
+  }
+
+  else if (rule instanceof Array) {
+    return (d) => {
+      row = {}
+      rule.forEach((k) => {
+        row[k] = d[rule[k]]
+      })
+      return row
+    }
+  }
+
+  else if (rule instanceof Object) {
+    return (d) => {
+      row = {}
+      Object.keys(rule).forEach((k) => {
+        row[k] = d[rule[k]]
+      })
+      return row
+    }
+  }
+
+  return // else
 }


### PR DESCRIPTION

* String / javascript形式(いままで通り)
   - `<chart columns="{key: d.srcKeyName}"></chart>`
* Object
   - `<chart :columns="{key: "srcKeyName"}"></chart>`
* Array
   - `<chart :columns="["key"]"></chart>`
* Function
   -  `<chart :columns="customParser"></chart>`
   - `EasyDC.Store.setBindData('customParser', function(d) { return {key: d.srcKeyName} })