### PR TITLE
Add bubble

### DIFF
--- a/docs/example/dashboard-01/index.html
+++ b/docs/example/dashboard-01/index.html
@@ -132,13 +132,11 @@
   <div class="container">
     <bubble
       dimension="d.session_end_date"
-      time-scale="ym"
-      reduces="{name: d.name, pv: d.pv, bounce_cnt: d.bounce_cnt, bounce_rate: {count: d.session_cnt, value: d.bounce_cnt}}"
+      time-scale="month"
+      time-format="ym"
+      reduce="{x: d.pv, y: d.bounce_cnt, radius: {count: d.session_cnt, value: d.bounce_cnt}}"
       :width=990
       :height=250
-      x-axis='pv'
-      y-axis='bounce_cnt'
-      radius='bounce_rate'
       radius-format='%'
       :max-bubble-relative-size=0.1
     ></bubble>

--- a/docs/example/dashboard-01/index.html
+++ b/docs/example/dashboard-01/index.html
@@ -133,7 +133,7 @@
     <bubble
       dimension="d.session_end_date"
       time-scale="month"
-      time-format="ym"
+      time-format="%Y-%m"
       reduce="{x: d.pv, y: d.bounce_cnt, radius: {count: d.session_cnt, value: d.bounce_cnt}}"
       :width=990
       :height=250

--- a/docs/example/dashboard-01/index.html
+++ b/docs/example/dashboard-01/index.html
@@ -77,6 +77,7 @@
     <stack-and-rate scale='time' dimension='d.session_end_date' volume='date-volume-chart' reduce='[[d.bounce_cnt, d.pv - d.bounce_cnt], {count: d.session_cnt, value: d.bounce_cnt}]'></stack-and-rate>
     <volume-chart scale='time' dimension='d.session_end_date' reduce='d.pv' id='date-volume-chart'></volume-chart>
   </div>
+
   <div>
     <list-row
        dimension='d.name'
@@ -93,8 +94,8 @@
     <ordinal-bar
       dimension='d.name'
       reduce='d.pv'
-      :width=768
-      :height=380
+      :width=300
+      :height=250
       x-axis-label='name'
       y-axis-label='pv'
     ></ordinal-bar>
@@ -102,9 +103,9 @@
       dimension='d.name'
       reduce='[d.pv, d.session_cnt, d.bounce_cnt]'
       :labels="['PV', 'セッション数', '離脱数']"
-      :width=768
-      :height=380
-      :legend-x=300
+      :width=300
+      :height=250
+      :legend-x=250
       x-axis-label='name'
       y-axis-label='pv + session_cnt + bounce_cnt'
     ></stacked-bar>
@@ -117,9 +118,9 @@
     <filter-stacked-bar
       dimensions="[d.name, d.meta]"
       reduce='d.pv'
-      :width=400
-      :height=400
-      :legend-x=350
+      :width=300
+      :height=250
+      :legend-x=250
       :legend-y=0
     ></filter-stacked-bar>
     <segment-pie
@@ -130,13 +131,16 @@
 
   <div class="container">
     <bubble
-      dimension="d.name"
+      dimension="d.session_end_date"
+      time-scale="ym"
       reduces="{name: d.name, pv: d.pv, bounce_cnt: d.bounce_cnt, bounce_rate: {count: d.session_cnt, value: d.bounce_cnt}}"
       :width=990
       :height=250
       x-axis='pv'
       y-axis='bounce_cnt'
       radius='bounce_rate'
+      radius-format='%'
+      :max-bubble-relative-size=0.1
     ></bubble>
   </div>
 

--- a/docs/example/dashboard-01/index.html
+++ b/docs/example/dashboard-01/index.html
@@ -103,6 +103,18 @@
   </div>
 
   <div class="container">
+    <bubble
+      dimension="d.name"
+      reduces="{name: d.name, pv: d.pv, bounce_cnt: d.bounce_cnt, bounce_rate: {count: d.session_cnt, value: d.bounce_cnt}}"
+      :width=990
+      :height=250
+      x-axis='pv'
+      y-axis='bounce_cnt'
+      radius='bounce_rate'
+    ></bubble>
+  </div>
+
+  <div class="container">
     <data-table
       dimension="d.name"
       columns="{name: d.name, pv: d.pv, bounce_cnt: d.bounce_cnt, bounce_rate: {count: d.session_cnt, value: d.bounce_cnt}}"

--- a/libs/chart/bubble.vue
+++ b/libs/chart/bubble.vue
@@ -12,14 +12,16 @@ import Base from './_base'
 import Store from '../store'
 import {generateExtractor} from '../utils'
 
-const _ymdFormat = (key) => d3.time.format("%Y-%m-%d")(key)
-const _ymFormat = (key) => d3.time.format("%Y-%m")(key)
-const _yearFormat = (key) => d3.time.format('%Y')(key)
-const _monthFormat = (key) => d3.time.format('%m')(key)
-const _dayFormat = (key) => d3.time.format('%d')(key)
-const _yearInterval = (key) => d3.time.year(key)
-const _monthInterval = (key) => d3.time.month(key)
-const _dayInterval = (key) => d3.time.day(key)
+const TIME_FORMATS = {
+  year: d3.time.format('%Y'),
+  month: d3.time.format('%m'),
+  day: d3.time.format('%d')
+}
+const TIME_INTERVALS = {
+  year: d3.time.year,
+  month: d3.time.month,
+  day: d3.time.day
+}
 
 export default {
   extends: Base,
@@ -189,17 +191,14 @@ export default {
     },
     getTimeInterval: function() {
       if(this.timeScale === undefined) return null
-      else if(this.timeScale === 'year') return _yearInterval
-      else if (this.timeScale === 'month') return _monthInterval
-      else if (this.timeScale === 'day') return _dayInterval
+      else return TIME_INTERVALS[this.timeScale]
     },
     getTimeFormat: function() {
-      if (this.timeFormat === undefined) return null
-      else if (this.timeFormat === 'ymd') return _ymdFormat
-      else if (this.timeFormat === 'ym') return _ymFormat
-      else if(this.timeFormat === 'year') return _yearFormat
-      else if (this.timeFormat === 'month') return _monthFormat
-      else if (this.timeFormat === 'day') return _dayFormat
+      if (this.timeScale === undefined) return null
+      // If time-format passed from props, then use it
+      else if (this.timeFormat) return d3.time.format(this.timeFormat)
+      // else format is automatically selected (depending on time-scale)
+      else return TIME_FORMATS[this.timeScale]
     }
   },
   mounted: function() {

--- a/libs/chart/bubble.vue
+++ b/libs/chart/bubble.vue
@@ -31,15 +31,13 @@ export default {
       type: String,
       default: 'bubbleChart'
     },
-    reduces: {
-      type: String
-    },
     timeScale: {
       type: String
     },
     timeFormat: {
       type: String
     },
+    // labels, formats
     xAxis: {
       type: String,
       default: 'x'
@@ -64,6 +62,7 @@ export default {
       type: String,
       default: ''
     },
+    // options
     renderLabel: {
       type: Boolean,
       default: true
@@ -80,10 +79,6 @@ export default {
       type: Boolean,
       default: true
     },
-    maxBubbleRelativeSize: {
-      type: Number,
-      default: 0.3
-    },
     sortBubbleSize: {
       type: Boolean,
       default: false
@@ -91,6 +86,11 @@ export default {
     elasticRadius: {
       type: Boolean,
       default: false
+    },
+    // styles
+    maxBubbleRelativeSize: {
+      type: Number,
+      default: 0.3
     },
     xAxisPadding: {
       type: Number,

--- a/libs/chart/bubble.vue
+++ b/libs/chart/bubble.vue
@@ -119,7 +119,7 @@ export default {
     grouping: function() {
       const getter = this.getDimensionExtractor;
       const interval = this.getTimeInterval()
-      const grouping = (d) => interval(getter(d))
+      const grouping = (interval === null) ? getter : (d) => interval(getter(d))
       return Store.registerDimension(this.dimensionName, grouping, {dataset: this.dataset})
     },
     reducer: function() {

--- a/libs/chart/bubble.vue
+++ b/libs/chart/bubble.vue
@@ -199,12 +199,16 @@ export default {
       else if (this.timeFormat) return d3.time.format(this.timeFormat)
       // else format is automatically selected (depending on time-scale)
       else return TIME_FORMATS[this.timeScale]
+    },
+    formatKey: function(key) {
+      const format = this.getTimeFormat()
+      if (format === null) return key
+      return format(key)
     }
   },
   mounted: function() {
     const chart = this.chart;
     const all = this.reducer.all()
-    const format = this.getTimeFormat()
 
     chart.transitionDuration(1500)
       .colors(d3.scale.category10())
@@ -225,9 +229,9 @@ export default {
       .renderVerticalGridLines(this.renderVerticalGridLines)
       .renderLabel(this.renderLabel)
       .renderTitle(this.renderTitle)
-      .label((p) => format(p.key))
+      .label((p) => this.formatKey(p.key))
       .title((p) => {
-        return `[${format(p.key)}]\n`
+        return `[${this.formatKey(p.key)}]\n`
           + `${this.xAxis}: ${this.extractValue(p.value[this.xAxis])}${this.xAxisFormat}\n`
           + `${this.yAxis}: ${this.extractValue(p.value[this.yAxis])}${this.yAxisFormat}\n`
           + `${this.radius}: ${this.extractValue(p.value[this.radius])}${this.radiusFormat}`

--- a/libs/chart/bubble.vue
+++ b/libs/chart/bubble.vue
@@ -125,7 +125,6 @@ export default {
   mounted: function() {
     const chart = this.chart;
     const all = this.reducer.all()
-    console.log(d3.extent(all, (d) => this.extractRateValue(d.value[this.radius])))
 
     chart.transitionDuration(1500)
       .colors(d3.scale.category10())

--- a/libs/chart/bubble.vue
+++ b/libs/chart/bubble.vue
@@ -1,0 +1,164 @@
+<template>
+  <div class="krt-dc-ordinal-bar" :id="id">
+    <a class="reset" style="display: none">reset</a>
+  </div>
+</template>
+
+<script lang='js'>
+
+import d3 from "d3"
+import dc from 'dc'
+import Base from './_base'
+import Store from '../store'
+import {generateExtractor} from '../utils'
+
+export default {
+  extends: Base,
+
+  props: {
+    chartType: {
+      type: String,
+      default: 'bubbleChart'
+    },
+    reduces: {
+      type: String
+    },
+    timeScale: {
+      type: String
+    },
+    xAxis: {
+      type: String
+    },
+    yAxis: {
+      type: String
+    },
+    radius: {
+      type: String
+    }
+  },
+  computed: {
+    getDimensionExtractor: function() {
+      if(this.timeScale) return new Function('d', `return d3.${this.timeScale}(${this.dimensionName})`)
+      return generateExtractor(this.dimensionName)
+    },
+    getReducersExtractor: function() {
+      return generateExtractor(this.reduces)
+    },
+    data: function() {
+      return (this.getReducersExtractor)(this.firstRow)
+    },
+    dataKeys: function() {
+      return Object.keys(this.data)
+    },
+    firstRow: function() {
+      const dim = Store.getDimension(this.dimensionName, this.getDimensionExtractor, {dataset: this.dataset});
+      return dim.top(1)[0]
+    },
+    reducer: function() {
+      const dim = Store.getDimension(this.dimensionName, this.getDimensionExtractor, {dataset: this.dataset});
+      const dimensionKey = this.extractDimensionName(this.dimension);
+      return dim.group().reduce(
+        (p, v) => {
+          const vals = this.getReducersExtractor(v);
+          this.dataKeys.forEach((k) => {
+            if (typeof(p[k]) === 'string' && typeof(vals[k]) === 'string') {
+              p[k] = vals[k]
+            }
+            else if (vals[k].count) {
+              p[k].count += vals[k].count;
+              p[k].value += vals[k].value;
+              p[k].per = p[k].count === 0 ? 0 : p[k].value / p[k].count;
+            }
+            else p[k] += vals[k]
+          })
+          p._count++;
+          return p;
+        },
+        (p, v) => {
+          const vals = this.getReducersExtractor(v);
+          this.dataKeys.forEach((k) => {
+            if (k === dimensionKey) {
+              p[k] = vals[k]
+            }
+            else if (vals[k].count) {
+              p[k].count -= vals[k].count;
+              p[k].value -= vals[k].value;
+              p[k].per = p[k].count === 0 ? 0 : p[k].value / p[k].count;
+            }
+            else p[k] -= vals[k]
+          })
+          p._count--;
+          return p;
+        },
+        () => {
+          const p = this.getSchema()
+          p._count = 0;
+          return p
+        }
+      )
+    }
+  },
+  methods: {
+    extractDimensionName: function(name) {
+      return name.replace(/d\./, '')
+    },
+    getSchema: function() {
+      const schema = {}
+      this.dataKeys.forEach((k) => {
+        val = this.data[k]
+        if(val instanceof String || typeof val === 'string') val = '';
+        else if(val instanceof Number || typeof val === 'number') val = 0;
+        else if(val instanceof Object || typeof val === 'object') {
+          val = {count: 0, value:0, per:0}
+        }
+        Object.assign(schema, {[k]: val})
+      })
+      return schema
+    },
+    extractRateValue: function(val) {
+      if(val instanceof Number || typeof val === 'number') return val
+      else if(val instanceof Object || typeof val === 'object') {
+        if(val.per != undefined) return val.per
+      }
+    }
+  },
+  mounted: function() {
+    const chart = this.chart;
+    const all = this.reducer.all()
+    console.log(d3.extent(all, (d) => this.extractRateValue(d.value[this.radius])))
+
+    chart.transitionDuration(1500)
+      .colors(d3.scale.category10())
+      .keyAccessor((p) => this.extractRateValue(p.value[this.xAxis]))
+      .valueAccessor((p) => this.extractRateValue(p.value[this.yAxis]))
+      .radiusValueAccessor((p) => this.extractRateValue(p.value[this.radius]))
+      .maxBubbleRelativeSize(0.3)
+      .x(d3.scale.linear().domain(d3.extent(all, (d) => this.extractRateValue(d.value[this.xAxis]))))
+      .y(d3.scale.linear().domain(d3.extent(all, (d) => this.extractRateValue(d.value[this.yAxis]))))
+      .r(d3.scale.linear().domain(d3.extent(all, (d) => this.extractRateValue(d.value[this.radius]))))
+      .elasticY(true)
+      .elasticX(true)
+      .xAxisPadding(500)
+      .yAxisPadding(100)
+      .renderHorizontalGridLines(true)
+      .renderVerticalGridLines(true)
+      .renderLabel(true)
+      .renderTitle(true)
+      // .label(function (p) {
+      //     return p.key.getFullYear();
+      // })
+      // .title(function (p) {
+      //     return p.key.getFullYear()
+      //             + "\n"
+      //             + "Index Gain: " + numberFormat(p.value.absGain) + "\n"
+      //             + "Index Gain in Percentage: " + numberFormat(p.value.percentageGain) + "%\n"
+      //             + "Fluctuation / Index Ratio: " + numberFormat(p.value.fluctuationPercentage) + "%";
+      // })
+      // .yAxis().tickFormat(function (v) {
+      //     return v + "%";
+      // });
+    return chart.render();
+  }
+}
+
+</script>

--- a/libs/chart/data-table.vue
+++ b/libs/chart/data-table.vue
@@ -142,7 +142,7 @@ export default {
       return Math.min(end, this.filteredSize)
     },
     firstRow: function() {
-      const dim = Store.registerDimension(this.dimensionName, this.getDimensionExtractor, {dataset: this.dataset});
+      const dim = Store.getDimension(this.dimensionName, this.getDimensionExtractor, {dataset: this.dataset});
       return dim.top(1)[0]
     },
     isFirstPage: function() {
@@ -152,7 +152,7 @@ export default {
       return ((this.ofs + this.pag) >= this.filteredSize) ? 'true' : null
     },
     grouping: function() {
-      const dim = Store.registerDimension(this.dimensionName, this.getDimensionExtractor, {dataset: this.dataset});
+      const dim = Store.getDimension(this.dimensionName, this.getDimensionExtractor, {dataset: this.dataset});
       const dimensionKey = this.extractDimensionName(this.dimension);
       const grouping = dim.group().reduce(
         (p, v) => {

--- a/libs/chart/index.js
+++ b/libs/chart/index.js
@@ -10,6 +10,7 @@ import StackedBar from './stacked-bar.vue'
 import FilterStackedBar from './filter-stacked-bar.vue'
 import GeoJP from './geo-jp.vue'
 import DataTable from './data-table.vue'
+import Bubble from './bubble.vue'
 
 const components = {
   'segment-pie': SegmentPie,
@@ -22,6 +23,7 @@ const components = {
   'filter-stacked-bar': FilterStackedBar,
   'geo-jp': GeoJP,
   'data-table': DataTable,
+  'bubble': Bubble,
   'stack-and-rate': compose(StackedLines, RateLine)
 }
 
@@ -43,6 +45,7 @@ export default {
   FilterStackedBar: FilterStackedBar,
   GeoJP: GeoJP,
   DataTable: DataTable,
+  Bubble: Bubble,
   compose: compose,
   install: install,
   installedComponents: components


### PR DESCRIPTION
**やったこと**
- バブルチャートを追加
- 一部fix

**document**
https://dc-js.github.io/dc.js/docs/html/dc.bubbleChart.html
mixin - https://dc-js.github.io/dc.js/docs/html/bubble-mixin.js.html

**example**
http://bl.ocks.org/jun9/5632043
https://dc-js.github.io/dc.js/vc/ -> [source](https://github.com/srvk/www/blob/master/erroranalysis/components/dcjs/web/vc/index.html)

<img width="1097" alt="2017-05-09 16 56 45" src="https://cloud.githubusercontent.com/assets/17084445/25840855/8406ba74-34d8-11e7-9895-33994a2f8eca.png">

**やってないこと**
マイナスの値が入ることを考慮していない
sampleでは `Math.abs` を使っている
```
p.absGain += +v.close - +v.open;
p.fluctuation += Math.abs(+v.close - +v.open);
```

**使い方**
```
    <bubble
      dimension="d.session_end_date"
      reduces="{name: d.name, pv: d.pv, bounce_cnt: d.bounce_cnt, bounce_rate: {count: d.session_cnt, value: d.bounce_cnt}}"
      time-scale='ym'
      :width=990
      :height=250
      x-axis='pv'
      y-axis='bounce_cnt'
      radius='bounce_rate'
      radius-format='%'
      :max-bubble-relative-size=0.1
    ></bubble>
```
- reducesにobject形式で渡す
- x軸、y軸、円に対して、適用する指標を指定する(x-axis, y-axis, radius)
  rateをどこに渡されても問題ないようにした。
- x-axis-format, y-axis-format, radius-formatで、指標の単位をつけられる
- max-bubble-relative-size, sort-bubble-size, elastic-radiusはbubble-chartのmixin

- dimensionにdate型(session_end_date)を渡すときにtime-scaleを指定するとformatされる
  (指定しなくても壊れはしない(`Fri May 05 2017 00:00:00 GMT+0900 (JST)`のように表示される)

```
time-scale -> formatted
------------------------
ymd -> yyyy-mm-dd
ym -> yyyy-mm
year -> yyyy
month -> mm
day -> dd
```


**備考**
bubble overlay なるものがあるらしい
- https://dc-js.github.io/dc.js/docs/html/dc.bubbleOverlay.html
- https://bost.ocks.org/mike/bubble-map/